### PR TITLE
feat(reports): implement reporting microservice for approved loans count

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,13 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':sqs-listener')
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':dynamo-db')
+	implementation project(':metrics')
+	implementation project(':reactive-web')
+	implementation project(':logger')
+	implementation project(':jwt')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -23,4 +30,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/src/main/resources/application-dev.yaml
+++ b/applications/app-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,22 @@
+aws:
+  region: "${AWS_SQS_REGION}"
+
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
+
+application:
+  security:
+    jwt:
+      expiration: 3600000
+      secret-key: "${JWT_SECRET_KEY}"
+
+logging:
+  level:
+    root: INFO

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -1,0 +1,28 @@
+aws:
+  region: "${AWS_SQS_REGION}"
+  dynamodb:
+    endpoint: "${AWS_DYNAMODB_ENDPOINT:http://localhost:8000}"
+
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
+
+application:
+  security:
+    jwt:
+      expiration: 7200000
+      secret-key: "${JWT_SECRET_KEY}"
+
+logging:
+  level:
+    org.springframework.r2dbc.core.DefaultDatabaseClient: DEBUG
+    org.springframework.transaction.interceptor: DEBUG
+    org.springframework.transaction.reactive: DEBUG
+    org.springframework.transaction: DEBUG
+    io.r2dbc.h2: DEBUG

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -1,0 +1,22 @@
+aws:
+  region: "${AWS_SQS_REGION}"
+
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
+
+application:
+  security:
+    jwt:
+      expiration: 1800000
+      secret-key: "${JWT_SECRET_KEY}"
+
+logging:
+  level:
+    root: WARN

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -9,3 +9,16 @@ spring:
     active: "${SPRING_PROFILES_ACTIVE:local}"
 server:
   port: "${PORT:8081}"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
+cors:
+  allowed-origins: "${CORS_ALLOWED_ORIGINS}"

--- a/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
@@ -1,6 +1,9 @@
 package co.com.pragma.crediya.config;
 
+import co.com.pragma.crediya.model.loan.gateways.ApprovedApplicationSummaryRepository;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,14 +35,15 @@ class UseCasesConfigTest {
     static class TestConfig {
 
         @Bean
-        public MyUseCase myUseCase() {
-            return new MyUseCase();
+        public ApprovedApplicationSummaryRepository repository() {
+            return Mockito.mock(ApprovedApplicationSummaryRepository.class);
         }
+
+        @Bean
+        public LoggerPort loggerPort() {
+            return Mockito.mock(LoggerPort.class);
+        }
+
     }
 
-    static class MyUseCase {
-        public String execute() {
-            return "MyUseCase Test";
-        }
-    }
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/common/constants/DomainConstants.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/common/constants/DomainConstants.java
@@ -1,0 +1,10 @@
+package co.com.pragma.crediya.model.common.constants;
+
+public final class DomainConstants {
+
+    private DomainConstants() {
+    }
+
+    public static final String ADMIN_ROLE = "ADMIN";
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
@@ -1,0 +1,6 @@
+package co.com.pragma.crediya.model.jwt;
+
+import java.util.List;
+
+public record Jwt(String subject, List<String> roles) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/gateways/JwtProviderPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/gateways/JwtProviderPort.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model.jwt.gateways;
+
+import co.com.pragma.crediya.model.jwt.Jwt;
+
+public interface JwtProviderPort {
+
+    Jwt parseToken(String token);
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ApprovedApplication(
+        UUID id,
+        OffsetDateTime approvedAt) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplicationSummary.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplicationSummary.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.time.Instant;
+
+public record ApprovedApplicationSummary(
+        String id,
+        long approvedApplicationsCount,
+        Instant lastUpdated) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApprovedApplicationSummaryFieldNames.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApprovedApplicationSummaryFieldNames.java
@@ -1,0 +1,18 @@
+package co.com.pragma.crediya.model.loan.constants;
+
+public final class ApprovedApplicationSummaryFieldNames {
+
+    private ApprovedApplicationSummaryFieldNames() {
+    }
+
+    public static final String TABLE_NAME = "ApprovedApplicationsSummary";
+
+    public static final String ID = "id";
+
+    public static final String SUMMARY = "summary";
+
+    public static final String APPROVED_APPLICATIONS_COUNT = "approvedApplicationsCount";
+
+    public static final String LAST_UPDATED = "lastUpdated";
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApprovedApplicationSummaryRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApprovedApplicationSummaryRepository.java
@@ -1,0 +1,12 @@
+package co.com.pragma.crediya.model.loan.gateways;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import reactor.core.publisher.Mono;
+
+public interface ApprovedApplicationSummaryRepository {
+
+    Mono<ApprovedApplicationSummary> incrementSummary(long countToAdd);
+
+    Mono<ApprovedApplicationSummary> getSummary();
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/logs/gateways/LoggerPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/logs/gateways/LoggerPort.java
@@ -1,0 +1,11 @@
+package co.com.pragma.crediya.model.logs.gateways;
+
+public interface LoggerPort {
+
+    void info(String message, Object... args);
+
+    void warn(String message, Object... args);
+
+    void error(String message, Object... args);
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/user/User.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/user/User.java
@@ -1,0 +1,4 @@
+package co.com.pragma.crediya.model.user;
+
+public record User(String email) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/user/constants/UserFieldNames.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/user/constants/UserFieldNames.java
@@ -1,0 +1,10 @@
+package co.com.pragma.crediya.model.user.constants;
+
+public final class UserFieldNames {
+
+    private UserFieldNames() {
+    }
+
+    public static final String ROLES = "roles";
+
+}

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCase.java
@@ -1,0 +1,29 @@
+package co.com.pragma.crediya.usecase.loan;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.gateways.ApprovedApplicationSummaryRepository;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import reactor.core.publisher.Mono;
+
+public record ApprovedApplicationSummaryUseCase(ApprovedApplicationSummaryRepository repository, LoggerPort logger) {
+
+    public Mono<Void> recordApprovedApplication(ApprovedApplication application) {
+        logger.info("Recording approved application ID {} at {}", application.id(), application.approvedAt());
+
+        return repository.incrementSummary(1L)
+                .doOnSuccess(summary -> logger.info("Updated summary: total approved count = {}", summary.approvedApplicationsCount()))
+                .doOnError(e -> logger.error("Failed to update approved applications summary. Reason: {}", e.getMessage(), e))
+                .then();
+    }
+
+    public Mono<ApprovedApplicationSummary> getApprovedApplicationsSummary() {
+        logger.info("Retrieving  approved applications summary");
+
+        return repository.getSummary()
+                .doOnSuccess(summary -> logger.info("Current summary: total approved count = {}", summary.approvedApplicationsCount()))
+                .doOnError(e -> logger.error("Failed to retrieve approved applications summary. Reason: {}", e.getMessage(), e));
+    }
+
+}
+

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCaseTest.java
@@ -1,0 +1,124 @@
+package co.com.pragma.crediya.usecase.loan;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import co.com.pragma.crediya.model.loan.gateways.ApprovedApplicationSummaryRepository;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+
+@ExtendWith(MockitoExtension.class)
+class ApprovedApplicationSummaryUseCaseTest {
+
+    @Mock
+    private ApprovedApplicationSummaryRepository repository;
+
+    @Mock
+    private LoggerPort logger;
+
+    private ApprovedApplicationSummaryUseCase useCase;
+
+    private ApprovedApplication application;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ApprovedApplicationSummaryUseCase(repository, logger);
+
+        application = new ApprovedApplication(UUID.randomUUID(), OffsetDateTime.now());
+    }
+
+    @Test
+    void recordApprovedApplication_WhenSuccessful_ShouldIncrementAndLog() {
+        ApprovedApplicationSummary updatedSummary = new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY, 5L, Instant.now());
+
+        when(repository.incrementSummary(1L))
+                .thenReturn(Mono.just(updatedSummary));
+
+        Mono<Void> result = useCase.recordApprovedApplication(application);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+
+        verify(repository).incrementSummary(1L);
+    }
+
+    @Test
+    void recordApprovedApplication_WhenRepositoryFails_ShouldLogErrorAndPropagateError() {
+        RuntimeException repositoryError = new RuntimeException("Database connection failed");
+
+        when(repository.incrementSummary(1L))
+                .thenReturn(Mono.error(repositoryError));
+
+        Mono<Void> result = useCase.recordApprovedApplication(application);
+
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+
+        verify(repository).incrementSummary(1L);
+    }
+
+    @Test
+    void getApprovedApplicationsSummary_WhenSuccessful_ShouldReturnSummaryAndLog() {
+        ApprovedApplicationSummary summary = new ApprovedApplicationSummary(
+                "summary", 10L, Instant.parse("2024-01-15T12:00:00Z"));
+
+        when(repository.getSummary())
+                .thenReturn(Mono.just(summary));
+
+        Mono<ApprovedApplicationSummary> result = useCase.getApprovedApplicationsSummary();
+
+        StepVerifier.create(result)
+                .expectNext(summary)
+                .verifyComplete();
+
+        verify(repository).getSummary();
+    }
+
+    @Test
+    void getApprovedApplicationsSummary_WhenRepositoryFails_ShouldLogErrorAndPropagateError() {
+        RuntimeException repositoryError = new RuntimeException("Network timeout");
+
+        when(repository.getSummary())
+                .thenReturn(Mono.error(repositoryError));
+
+        Mono<ApprovedApplicationSummary> result = useCase.getApprovedApplicationsSummary();
+
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+
+        verify(repository).getSummary();
+    }
+
+    @Test
+    void getApprovedApplicationsSummary_WhenReturnsEmptySummary_ShouldHandleGracefully() {
+        ApprovedApplicationSummary emptySummary = new ApprovedApplicationSummary("summary", 0L, null);
+
+        when(repository.getSummary())
+                .thenReturn(Mono.just(emptySummary));
+
+        Mono<ApprovedApplicationSummary> result = useCase.getApprovedApplicationsSummary();
+
+        StepVerifier.create(result)
+                .expectNext(emptySummary)
+                .verifyComplete();
+    }
+
+}

--- a/infrastructure/driven-adapters/dynamo-db/build.gradle
+++ b/infrastructure/driven-adapters/dynamo-db/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'software.amazon.awssdk:dynamodb-enhanced'
+    implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
+    testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/ApprovedApplicationSummaryItemAdapter.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/ApprovedApplicationSummaryItemAdapter.java
@@ -1,0 +1,79 @@
+package co.com.pragma.crediya.dynamodb;
+
+import co.com.pragma.crediya.dynamodb.converters.ApprovedApplicationSummaryConverter;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import co.com.pragma.crediya.model.loan.gateways.ApprovedApplicationSummaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class ApprovedApplicationSummaryItemAdapter implements ApprovedApplicationSummaryRepository {
+
+    private final DynamoDbAsyncClient lowLevelClient;
+
+    private final ApprovedApplicationSummaryConverter converter;
+
+    @Override
+    public Mono<ApprovedApplicationSummary> incrementSummary(long countToAdd) {
+        Map<String, AttributeValue> key = buildKey();
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .tableName(ApprovedApplicationSummaryFieldNames.TABLE_NAME)
+                .key(key)
+                .updateExpression("ADD #count :countInc SET #lastUpdated = :now")
+                .expressionAttributeNames(buildExpressionAttributeNames())
+                .expressionAttributeValues(buildIncrementExpressionValues(countToAdd))
+                .returnValues(ReturnValue.ALL_NEW)
+                .build();
+
+        return Mono.fromFuture(() -> lowLevelClient.updateItem(request))
+                .map(UpdateItemResponse::attributes)
+                .map(converter::fromDynamoDbAttributes);
+    }
+
+    @Override
+    public Mono<ApprovedApplicationSummary> getSummary() {
+        Map<String, AttributeValue> key = buildKey();
+
+        GetItemRequest request = GetItemRequest.builder()
+                .tableName(ApprovedApplicationSummaryFieldNames.TABLE_NAME)
+                .key(key)
+                .build();
+
+        return Mono.fromFuture(() -> lowLevelClient.getItem(request))
+                .filter(GetItemResponse::hasItem)
+                .map(GetItemResponse::item)
+                .map(converter::fromDynamoDbAttributes)
+                .switchIfEmpty(Mono.fromSupplier(() -> converter.fromDynamoDbAttributes(null)));
+    }
+
+    private Map<String, AttributeValue> buildKey() {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put(ApprovedApplicationSummaryFieldNames.ID, AttributeValue.builder().s(ApprovedApplicationSummaryFieldNames.SUMMARY).build());
+        return key;
+    }
+
+    private Map<String, String> buildExpressionAttributeNames() {
+        Map<String, String> names = new HashMap<>();
+        names.put("#count", ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT);
+        names.put("#lastUpdated", ApprovedApplicationSummaryFieldNames.LAST_UPDATED);
+        return names;
+    }
+
+    private Map<String, AttributeValue> buildIncrementExpressionValues(long countToAdd) {
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":countInc", AttributeValue.builder().n(Long.toString(countToAdd)).build());
+        values.put(":now", AttributeValue.builder().s(Instant.now().toString()).build());
+        return values;
+    }
+
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfig.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfig.java
@@ -1,0 +1,49 @@
+package co.com.pragma.crediya.dynamodb.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+import java.net.URI;
+
+@Configuration
+public class DynamoDBConfig {
+
+    @Bean
+    @Profile({"local"})
+    public DynamoDbAsyncClient amazonDynamoDB(@Value("${aws.dynamodb.endpoint}") String endpoint,
+                                              @Value("${aws.region}") String region,
+                                              MetricPublisher publisher) {
+        return DynamoDbAsyncClient.builder()
+                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .build();
+    }
+
+    @Bean
+    @Profile({"dev", "prod"})
+    public DynamoDbAsyncClient amazonDynamoDBAsync(MetricPublisher publisher, @Value("${aws.region}") String region) {
+        return DynamoDbAsyncClient.builder()
+                .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .region(Region.of(region))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .build();
+    }
+
+    @Bean
+    public DynamoDbEnhancedAsyncClient getDynamoDbEnhancedAsyncClient(DynamoDbAsyncClient client) {
+        return DynamoDbEnhancedAsyncClient.builder()
+                .dynamoDbClient(client)
+                .build();
+    }
+
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/converters/ApprovedApplicationSummaryConverter.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/converters/ApprovedApplicationSummaryConverter.java
@@ -1,0 +1,71 @@
+package co.com.pragma.crediya.dynamodb.converters;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class ApprovedApplicationSummaryConverter {
+
+    public ApprovedApplicationSummary fromDynamoDbAttributes(Map<String, AttributeValue> attributes) {
+        if (attributes == null || attributes.isEmpty()) {
+            return createDefaultSummary();
+        }
+
+        String id = extractId(attributes);
+        Long count = extractCount(attributes);
+        Instant lastUpdated = extractLastUpdated(attributes);
+
+        return new ApprovedApplicationSummary(id, count, lastUpdated);
+    }
+
+    private ApprovedApplicationSummary createDefaultSummary() {
+        return new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY,
+                0L,
+                null
+        );
+    }
+
+    private String extractId(Map<String, AttributeValue> attributes) {
+        return Optional.ofNullable(attributes.get(ApprovedApplicationSummaryFieldNames.ID))
+                .map(AttributeValue::s)
+                .orElse(ApprovedApplicationSummaryFieldNames.SUMMARY);
+    }
+
+    private Long extractCount(Map<String, AttributeValue> attributes) {
+        return Optional.ofNullable(attributes.get(ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT))
+                .map(AttributeValue::n)
+                .map(this::parseToLong)
+                .orElse(0L);
+    }
+
+    private Instant extractLastUpdated(Map<String, AttributeValue> attributes) {
+        return Optional.ofNullable(attributes.get(ApprovedApplicationSummaryFieldNames.LAST_UPDATED))
+                .map(AttributeValue::s)
+                .map(this::parseToInstant)
+                .orElse(null);
+    }
+
+    private Long parseToLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private Instant parseToInstant(String value) {
+        try {
+            return Instant.parse(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/ApprovedApplicationSummaryItemAdapterTest.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/ApprovedApplicationSummaryItemAdapterTest.java
@@ -1,0 +1,204 @@
+package co.com.pragma.crediya.dynamodb;
+
+import co.com.pragma.crediya.dynamodb.converters.ApprovedApplicationSummaryConverter;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApprovedApplicationSummaryItemAdapterTest {
+
+    @Mock
+    private DynamoDbAsyncClient lowLevelClient;
+
+    @Mock
+    private ApprovedApplicationSummaryConverter converter;
+
+    private ApprovedApplicationSummaryItemAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ApprovedApplicationSummaryItemAdapter(lowLevelClient, converter);
+    }
+
+    @Test
+    void incrementSummaryWhenSuccessfulShouldReturnUpdatedSummary() {
+        long countToAdd = 5L;
+        Map<String, AttributeValue> responseAttributes = createMockAttributes(10L, "2024-01-15T10:30:00Z");
+        ApprovedApplicationSummary expectedSummary = new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY,
+                10L,
+                Instant.parse("2024-01-15T10:30:00Z")
+        );
+
+        UpdateItemResponse updateResponse = UpdateItemResponse.builder()
+                .attributes(responseAttributes)
+                .build();
+
+        when(lowLevelClient.updateItem(any(UpdateItemRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(updateResponse));
+
+        when(converter.fromDynamoDbAttributes(responseAttributes))
+                .thenReturn(expectedSummary);
+
+        StepVerifier.create(adapter.incrementSummary(countToAdd))
+                .expectNext(expectedSummary)
+                .verifyComplete();
+
+        ArgumentCaptor<UpdateItemRequest> requestCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(lowLevelClient).updateItem(requestCaptor.capture());
+
+        UpdateItemRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.tableName()).isEqualTo(ApprovedApplicationSummaryFieldNames.TABLE_NAME);
+        assertThat(capturedRequest.returnValues()).isEqualTo(ReturnValue.ALL_NEW);
+        assertThat(capturedRequest.updateExpression()).contains("ADD #count :countInc");
+        assertThat(capturedRequest.updateExpression()).contains("SET #lastUpdated = :now");
+
+        Map<String, AttributeValue> values = capturedRequest.expressionAttributeValues();
+        assertThat(values.get(":countInc").n()).isEqualTo("5");
+        assertThat(values.get(":now").s()).isNotNull();
+
+        assertThat(capturedRequest.expressionAttributeNames())
+                .containsEntry("#count", ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT)
+                .containsEntry("#lastUpdated", ApprovedApplicationSummaryFieldNames.LAST_UPDATED);
+
+        verify(converter).fromDynamoDbAttributes(responseAttributes);
+    }
+
+    @Test
+    void incrementSummaryWhenDynamoDbFailsShouldPropagateError() {
+        long countToAdd = 3L;
+        RuntimeException dynamoException = new RuntimeException("DynamoDB error");
+
+        when(lowLevelClient.updateItem(any(UpdateItemRequest.class)))
+                .thenReturn(CompletableFuture.failedFuture(dynamoException));
+
+        StepVerifier.create(adapter.incrementSummary(countToAdd))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        verify(converter, never()).fromDynamoDbAttributes(any());
+    }
+
+    @Test
+    void getSummaryWhenItemExistsShouldReturnSummary() {
+        Map<String, AttributeValue> responseAttributes = createMockAttributes(15L, "2024-01-15T11:00:00Z");
+        ApprovedApplicationSummary expectedSummary = new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY,
+                15L,
+                Instant.parse("2024-01-15T11:00:00Z")
+        );
+
+        GetItemResponse getResponse = GetItemResponse.builder()
+                .item(responseAttributes)
+                .build();
+
+        when(lowLevelClient.getItem(any(GetItemRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(getResponse));
+
+        when(converter.fromDynamoDbAttributes(responseAttributes))
+                .thenReturn(expectedSummary);
+
+        StepVerifier.create(adapter.getSummary())
+                .expectNext(expectedSummary)
+                .verifyComplete();
+
+        ArgumentCaptor<GetItemRequest> requestCaptor = ArgumentCaptor.forClass(GetItemRequest.class);
+        verify(lowLevelClient).getItem(requestCaptor.capture());
+
+        GetItemRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.tableName()).isEqualTo(ApprovedApplicationSummaryFieldNames.TABLE_NAME);
+
+        Map<String, AttributeValue> key = capturedRequest.key();
+        assertThat(key.get(ApprovedApplicationSummaryFieldNames.ID).s()).isEqualTo(ApprovedApplicationSummaryFieldNames.SUMMARY);
+
+        verify(converter).fromDynamoDbAttributes(responseAttributes);
+    }
+
+    @Test
+    void getSummaryWhenItemDoesNotExistShouldReturnDefault() {
+        GetItemResponse emptyResponse = GetItemResponse.builder().build(); // No item
+        ApprovedApplicationSummary defaultSummary = new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY,
+                0L,
+                null
+        );
+
+        when(lowLevelClient.getItem(any(GetItemRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(emptyResponse));
+
+        when(converter.fromDynamoDbAttributes(null))
+                .thenReturn(defaultSummary);
+
+        StepVerifier.create(adapter.getSummary())
+                .expectNext(defaultSummary)
+                .verifyComplete();
+
+        verify(converter).fromDynamoDbAttributes(null);
+    }
+
+    @Test
+    void getSummaryWhenDynamoDbFailsShouldPropagateError() {
+        RuntimeException dynamoException = new RuntimeException("DynamoDB connection error");
+
+        when(lowLevelClient.getItem(any(GetItemRequest.class)))
+                .thenReturn(CompletableFuture.failedFuture(dynamoException));
+
+        StepVerifier.create(adapter.getSummary())
+                .expectError(RuntimeException.class)
+                .verify();
+
+        verify(converter, never()).fromDynamoDbAttributes(any());
+    }
+
+    @Test
+    void getSummaryWhenItemNotFoundShouldReturnDefaultFromConverter() {
+        GetItemResponse emptyResponse = GetItemResponse.builder()
+                .build();
+
+        ApprovedApplicationSummary defaultSummary = new ApprovedApplicationSummary(
+                ApprovedApplicationSummaryFieldNames.SUMMARY, 0L, null);
+
+        when(lowLevelClient.getItem(any(GetItemRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(emptyResponse));
+
+        when(converter.fromDynamoDbAttributes(null))
+                .thenReturn(defaultSummary);
+
+        StepVerifier.create(adapter.getSummary())
+                .expectNext(defaultSummary)
+                .verifyComplete();
+    }
+
+    private Map<String, AttributeValue> createMockAttributes(Long count, String lastUpdated) {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.ID,
+                AttributeValue.builder().s(ApprovedApplicationSummaryFieldNames.SUMMARY).build());
+        attributes.put(ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT,
+                AttributeValue.builder().n(count.toString()).build());
+
+        if (lastUpdated != null) {
+            attributes.put(ApprovedApplicationSummaryFieldNames.LAST_UPDATED,
+                    AttributeValue.builder().s(lastUpdated).build());
+        }
+
+        return attributes;
+    }
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfigTest.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfigTest.java
@@ -1,0 +1,52 @@
+package co.com.pragma.crediya.dynamodb.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class DynamoDBConfigTest {
+
+    @Mock
+    private MetricPublisher publisher;
+
+    @Mock
+    private DynamoDbAsyncClient dynamoDbAsyncClient;
+
+    private final DynamoDBConfig dynamoDBConfig = new DynamoDBConfig();
+
+    @Test
+    void testAmazonDynamoDB() {
+
+        DynamoDbAsyncClient result = dynamoDBConfig.amazonDynamoDB(
+                "http://aws.dynamo.test",
+                "region",
+                publisher);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testAmazonDynamoDBAsync() {
+
+        DynamoDbAsyncClient result = dynamoDBConfig.amazonDynamoDBAsync(
+                publisher,
+                "region");
+
+        assertNotNull(result);
+    }
+
+
+    @Test
+    void testGetDynamoDbEnhancedAsyncClient() {
+        DynamoDbEnhancedAsyncClient result = dynamoDBConfig.getDynamoDbEnhancedAsyncClient(dynamoDbAsyncClient);
+
+        assertNotNull(result);
+    }
+}

--- a/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/converters/ApprovedApplicationSummaryConverterTest.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/crediya/dynamodb/converters/ApprovedApplicationSummaryConverterTest.java
@@ -1,0 +1,109 @@
+package co.com.pragma.crediya.dynamodb.converters;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApprovedApplicationSummaryConverterTest {
+
+    private ApprovedApplicationSummaryConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new ApprovedApplicationSummaryConverter();
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithValidAttributesShouldConvertCorrectly() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.ID,
+                AttributeValue.builder().s(ApprovedApplicationSummaryFieldNames.SUMMARY).build());
+        attributes.put(ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT,
+                AttributeValue.builder().n("42").build());
+        attributes.put(ApprovedApplicationSummaryFieldNames.LAST_UPDATED,
+                AttributeValue.builder().s("2024-01-15T10:30:00Z").build());
+
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(attributes);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(ApprovedApplicationSummaryFieldNames.SUMMARY);
+        assertThat(result.approvedApplicationsCount()).isEqualTo(42L);
+        assertThat(result.lastUpdated()).isEqualTo(Instant.parse("2024-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithNullAttributesShouldReturnDefault() {
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(ApprovedApplicationSummaryFieldNames.SUMMARY);
+        assertThat(result.approvedApplicationsCount()).isZero();
+        assertThat(result.lastUpdated()).isNull();
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithEmptyAttributesShouldReturnDefault() {
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(new HashMap<>());
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(ApprovedApplicationSummaryFieldNames.SUMMARY);
+        assertThat(result.approvedApplicationsCount()).isZero();
+        assertThat(result.lastUpdated()).isNull();
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithMissingCountShouldDefaultToZero() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.ID,
+                AttributeValue.builder().s(ApprovedApplicationSummaryFieldNames.SUMMARY).build());
+        attributes.put(ApprovedApplicationSummaryFieldNames.LAST_UPDATED,
+                AttributeValue.builder().s("2024-01-15T10:30:00Z").build());
+
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(attributes);
+
+        assertThat(result.approvedApplicationsCount()).isZero();
+        assertThat(result.lastUpdated()).isEqualTo(Instant.parse("2024-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithInvalidNumberShouldDefaultToZero() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT,
+                AttributeValue.builder().n("invalid-number").build());
+
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(attributes);
+
+        assertThat(result.approvedApplicationsCount()).isZero();
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithInvalidDateShouldSetLastUpdatedToNull() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.LAST_UPDATED,
+                AttributeValue.builder().s("invalid-date").build());
+
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(attributes);
+
+        assertThat(result.lastUpdated()).isNull();
+    }
+
+    @Test
+    void fromDynamoDbAttributesWithMissingLastUpdatedShouldSetToNull() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        attributes.put(ApprovedApplicationSummaryFieldNames.APPROVED_APPLICATIONS_COUNT,
+                AttributeValue.builder().n("10").build());
+
+        ApprovedApplicationSummary result = converter.fromDynamoDbAttributes(attributes);
+
+        assertThat(result.lastUpdated()).isNull();
+    }
+
+}

--- a/infrastructure/driven-adapters/jwt/build.gradle
+++ b/infrastructure/driven-adapters/jwt/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+}

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
@@ -1,0 +1,59 @@
+package co.com.pragma.crediya.jwt;
+
+import co.com.pragma.crediya.jwt.config.JwtProperties;
+import co.com.pragma.crediya.model.jwt.Jwt;
+import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
+import co.com.pragma.crediya.model.user.constants.UserFieldNames;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProviderAdapter implements JwtProviderPort {
+
+    private final JwtProperties properties;
+
+    @Override
+    public Jwt parseToken(String token) {
+        Claims claims = extractClaims(token);
+
+        String subject = extractSubject(claims);
+        List<String> roles = extractRole(claims);
+
+        return new Jwt(subject, roles);
+    }
+
+    private SecretKey getSecretKey() {
+        String secretKey = properties.getSecretKey();
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractRole(Claims claims) {
+        Object value = claims.get(UserFieldNames.ROLES);
+        return value != null ? (List<String>) value : Collections.emptyList();
+    }
+
+    private String extractSubject(Claims claims) {
+        return claims.getSubject();
+    }
+
+}

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
@@ -1,0 +1,18 @@
+package co.com.pragma.crediya.jwt.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "application.security.jwt")
+public class JwtProperties {
+
+    private String secretKey;
+
+    private long expiration;
+
+}

--- a/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
+++ b/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
@@ -1,0 +1,53 @@
+package co.com.pragma.crediya.jwt;
+
+import co.com.pragma.crediya.jwt.config.JwtProperties;
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.jwt.Jwt;
+import co.com.pragma.crediya.model.user.User;
+import co.com.pragma.crediya.model.user.constants.UserFieldNames;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderAdapterTest {
+
+    private JwtProviderAdapter adapter;
+
+    private User user;
+
+    private final JwtProperties properties = new JwtProperties();
+
+    @BeforeEach
+    void setUp() {
+        properties.setSecretKey("q/MbiTiaKL9wCSeISqOlOQvDjg7s+xmYRtNhYbq7T3A=");
+        properties.setExpiration(10000L);
+
+        adapter = new JwtProviderAdapter(properties);
+
+        user = new User("johndoe@example.com");
+    }
+
+    @Test
+    void parseToken_shouldReturnJwt() {
+        String token = Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .subject(user.email())
+                .claim(UserFieldNames.ROLES, List.of(DomainConstants.ADMIN_ROLE))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.getSecretKey())))
+                .compact();
+
+        Jwt jwt = adapter.parseToken(token);
+
+        assertThat(jwt).isNotNull();
+        assertThat(jwt.subject()).isEqualTo(user.email());
+        assertThat(jwt.roles()).containsExactly(DomainConstants.ADMIN_ROLE);
+    }
+
+}

--- a/infrastructure/driven-adapters/logger/build.gradle
+++ b/infrastructure/driven-adapters/logger/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+}

--- a/infrastructure/driven-adapters/logger/src/main/java/co/com/pragma/crediya/logger/Slf4jLoggerAdapter.java
+++ b/infrastructure/driven-adapters/logger/src/main/java/co/com/pragma/crediya/logger/Slf4jLoggerAdapter.java
@@ -1,0 +1,28 @@
+package co.com.pragma.crediya.logger;
+
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public record Slf4jLoggerAdapter(Logger logger) implements LoggerPort {
+
+    public Slf4jLoggerAdapter(Class<?> logger) {
+        this(LoggerFactory.getLogger(logger));
+    }
+
+    @Override
+    public void info(String message, Object... args) {
+        logger.info(message, args);
+    }
+
+    @Override
+    public void warn(String message, Object... args) {
+        logger.warn(message, args);
+    }
+
+    @Override
+    public void error(String message, Object... args) {
+        logger.error(message, args);
+    }
+
+}

--- a/infrastructure/driven-adapters/logger/src/main/java/co/com/pragma/crediya/logger/config/LoggerConfig.java
+++ b/infrastructure/driven-adapters/logger/src/main/java/co/com/pragma/crediya/logger/config/LoggerConfig.java
@@ -1,0 +1,18 @@
+package co.com.pragma.crediya.logger.config;
+
+import co.com.pragma.crediya.logger.Slf4jLoggerAdapter;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class LoggerConfig {
+
+    @Bean
+    @Scope("prototype")
+    public LoggerPort logger(InjectionPoint injectionPoint) {
+        return new Slf4jLoggerAdapter(injectionPoint.getMember().getDeclaringClass());
+    }
+}

--- a/infrastructure/driven-adapters/logger/src/test/java/co/com/pragma/crediya/logger/Slf4jLoggerAdapterTest.java
+++ b/infrastructure/driven-adapters/logger/src/test/java/co/com/pragma/crediya/logger/Slf4jLoggerAdapterTest.java
@@ -1,0 +1,57 @@
+package co.com.pragma.crediya.logger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class Slf4jLoggerAdapterTest {
+
+    @Mock
+    private Logger logger;
+
+    private Slf4jLoggerAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new Slf4jLoggerAdapter(logger);
+    }
+
+    @Test
+    void constructor_withClass_shouldCreateLogger() {
+        Slf4jLoggerAdapter adapterWithClass = new Slf4jLoggerAdapter(Slf4jLoggerAdapterTest.class);
+
+        assertNotNull(adapterWithClass.logger());
+    }
+
+    @Test
+    void info_shouldDelegateToLogger() {
+        adapter.info("info message {}", "arg");
+
+        verify(logger).info(eq("info message {}"), AdditionalMatchers.aryEq(new Object[]{"arg"}));
+    }
+
+    @Test
+    void warn_shouldDelegateToLogger() {
+        adapter.warn("warn message {}", "arg");
+
+        verify(logger).warn(eq("warn message {}"), AdditionalMatchers.aryEq(new Object[]{"arg"}));
+
+    }
+
+    @Test
+    void error_shouldDelegateToLogger() {
+        adapter.error("error message {}", "arg");
+
+        verify(logger).error(eq("error message {}"), AdditionalMatchers.aryEq(new Object[]{"arg"}));
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    implementation project(':usecase')
+    implementation project(':model')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.11'
+
+    // Mapstruct
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/ReportsHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/ReportsHandler.java
@@ -1,0 +1,29 @@
+package co.com.pragma.crediya.api;
+
+import co.com.pragma.crediya.api.mapper.ApprovedApplicationsSummaryRestMapper;
+import co.com.pragma.crediya.usecase.loan.ApprovedApplicationSummaryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class ReportsHandler {
+
+    private final ApprovedApplicationSummaryUseCase approvedApplicationSummaryUseCase;
+
+    private final ApprovedApplicationsSummaryRestMapper mapper;
+
+    public Mono<ServerResponse> getApprovedLoansCount() {
+        return approvedApplicationSummaryUseCase.getApprovedApplicationsSummary()
+                .map(mapper::toResponse)
+                .flatMap(report ->
+                        ServerResponse.ok()
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .bodyValue(report)
+                );
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
@@ -1,0 +1,58 @@
+package co.com.pragma.crediya.api;
+
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.dto.ApprovedApplicationsSummaryResponse;
+import co.com.pragma.crediya.api.exceptions.ProblemDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springdoc.core.annotations.RouterOperation;
+import org.springdoc.core.annotations.RouterOperations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class RouterRest {
+
+    @Bean
+    @RouterOperations({
+            @RouterOperation(
+                    path = ApiConstants.REPORTS_PATH,
+                    produces = {MediaType.APPLICATION_JSON_VALUE},
+                    method = RequestMethod.GET,
+                    beanClass = ReportsHandler.class,
+                    beanMethod = "getApprovedLoansCount",
+                    operation = @Operation(
+                            operationId = "getApprovedLoansCount",
+                            summary = "Get approved loans count",
+                            description = "Retrieves the total number of approved loan applications and the last updated timestamp.",
+                            security = @SecurityRequirement(name = "bearerAuth"),
+                            responses = {
+                                    @ApiResponse(
+                                            responseCode = "200",
+                                            description = "Approved loans count retrieved successfully",
+                                            content = @Content(schema = @Schema(implementation = ApprovedApplicationsSummaryResponse.class))
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "500",
+                                            description = "Internal server error while fetching the approved loans count",
+                                            content = @Content(schema = @Schema(implementation = ProblemDetails.class))
+                                    )
+                            }
+                    )
+            )
+    })
+    public RouterFunction<ServerResponse> routerFunction(ReportsHandler handler) {
+        return RouterFunctions.route()
+                .GET(ApiConstants.REPORTS_PATH, serverRequest -> handler.getApprovedLoansCount())
+                .build();
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/CorsConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package co.com.pragma.crediya.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    CorsWebFilter corsWebFilter(@Value("${cors.allowed-origins}") String origins) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of(origins.split(",")));
+        config.setAllowedMethods(Arrays.asList("POST", "GET"));
+        config.setAllowedHeaders(List.of(CorsConfiguration.ALL));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/OpenApiConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package co.com.pragma.crediya.api.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_KEY = "bearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Crediya Reports Microservice")
+                        .version("1.0.0")
+                        .description("This is the API for Reports Applications Microservice"))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_KEY, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")));
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/JwtAuthenticationManager.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/JwtAuthenticationManager.java
@@ -1,0 +1,42 @@
+package co.com.pragma.crediya.api.config.security;
+
+import co.com.pragma.crediya.api.exceptions.JwtAuthenticationException;
+import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationManager implements ReactiveAuthenticationManager {
+
+    private final JwtProviderPort jwtProviderPort;
+
+    @Override
+    public Mono<Authentication> authenticate(Authentication authentication) {
+        String token = authentication.getCredentials().toString();
+
+        return Mono.just(authentication)
+                .map(auth -> jwtProviderPort.parseToken(auth.getCredentials().toString()))
+                .onErrorResume(e -> {
+                    if (e instanceof ExpiredJwtException) {
+                        return Mono.error(JwtAuthenticationException.expiredToken());
+                    } else {
+                        return Mono.error(JwtAuthenticationException.invalidToken());
+                    }
+                })
+                .map(jwt -> new UsernamePasswordAuthenticationToken(
+                        jwt.subject(),
+                        token,
+                        jwt.roles().stream()
+                                .map(SimpleGrantedAuthority::new)
+                                .toList()
+                ));
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
@@ -1,0 +1,44 @@
+package co.com.pragma.crediya.api.config.security;
+
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.exceptions.handler.CustomAccessDeniedHandler;
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final SecurityContextRepository securityContextRepository;
+
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Bean
+    public SecurityWebFilterChain filterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .authorizeExchange(exchangeSpec -> exchangeSpec
+                        .pathMatchers(ApiConstants.PUBLIC_PATTERNS)
+                        .permitAll()
+                        .pathMatchers(HttpMethod.GET, ApiConstants.REPORTS_PATH)
+                        .hasAnyAuthority(
+                                DomainConstants.ADMIN_ROLE
+                        )
+                        .anyExchange().authenticated()
+                )
+                .securityContextRepository(securityContextRepository)
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.accessDeniedHandler(accessDeniedHandler)
+                )
+                .build();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityContextRepository.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityContextRepository.java
@@ -1,0 +1,65 @@
+package co.com.pragma.crediya.api.config.security;
+
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.exceptions.JwtAuthenticationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityContextRepository implements ServerSecurityContextRepository {
+
+    private final JwtAuthenticationManager jwtAuthenticationManager;
+
+    @Override
+    public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<SecurityContext> load(ServerWebExchange exchange) {
+        String path = exchange.getRequest().getPath().value();
+
+        if (isPublicPath(path)) {
+            return Mono.empty();
+        }
+
+        String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (authHeader == null) {
+            return Mono.error(JwtAuthenticationException.missingToken());
+        }
+
+        if (!authHeader.startsWith(ApiConstants.BEARER_PREFIX)) {
+            return Mono.error(JwtAuthenticationException.invalidToken());
+        }
+
+        String token = authHeader.substring(ApiConstants.BEARER_PREFIX_LENGTH);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(token, token);
+
+        return jwtAuthenticationManager
+                .authenticate(auth)
+                .map(SecurityContextImpl::new);
+    }
+
+    private boolean isPublicPath(String path) {
+        return Arrays.stream(ApiConstants.PUBLIC_PATTERNS)
+                .anyMatch(pattern -> {
+                    if (pattern.endsWith("/**")) {
+                        String basePath = pattern.substring(0, pattern.length() - 3);
+                        return path.startsWith(basePath);
+                    }
+                    return path.equals(pattern);
+                });
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityHeadersConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityHeadersConfig.java
@@ -1,0 +1,25 @@
+package co.com.pragma.crediya.api.config.security;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SecurityHeadersConfig implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        HttpHeaders headers = exchange.getResponse().getHeaders();
+        headers.set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'self'; form-action 'self'");
+        headers.set("Strict-Transport-Security", "max-age=31536000;");
+        headers.set("X-Content-Type-Options", "nosniff");
+        headers.set("Server", "");
+        headers.set("Cache-Control", "no-store");
+        headers.set("Pragma", "no-cache");
+        headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+        return chain.filter(exchange);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
@@ -1,0 +1,25 @@
+package co.com.pragma.crediya.api.constants;
+
+public final class ApiConstants {
+
+    private ApiConstants() {
+    }
+
+    public static final String API_V1 = "/api/v1";
+
+    public static final String REPORTS_PATH = API_V1 + "/reports";
+
+    public static final String[] PUBLIC_PATTERNS = {
+            "/actuator",
+            "/actuator/health",
+            "/actuator/prometheus",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/AuthErrorMessages.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/AuthErrorMessages.java
@@ -1,0 +1,16 @@
+package co.com.pragma.crediya.api.constants;
+
+public final class AuthErrorMessages {
+
+    private AuthErrorMessages() {
+    }
+
+    public static final String INVALID_TOKEN = "Invalid JWT token. Please log in again.";
+
+    public static final String EXPIRED_TOKEN = "JWT token has expired. Please log in again.";
+
+    public static final String MISSING_TOKEN = "Authorization token is missing.";
+
+    public static final String FORBIDDEN_ACCESS = "You do not have permission to access this resource.";
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/HttpErrorTitles.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/HttpErrorTitles.java
@@ -1,0 +1,16 @@
+package co.com.pragma.crediya.api.constants;
+
+public final class HttpErrorTitles {
+
+    private HttpErrorTitles() {
+    }
+
+    public static final String FORBIDDEN = "Forbidden";
+
+    public static final String UNAUTHORIZED = "Unauthorized";
+
+    public static final String BAD_REQUEST = "Bad Request Parameters";
+
+    public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ApprovedApplicationsSummaryResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ApprovedApplicationsSummaryResponse.java
@@ -1,0 +1,22 @@
+package co.com.pragma.crediya.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApprovedApplicationsSummaryResponse {
+
+    private long approvedApplicationsCount;
+
+    private Instant lastUpdated;
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/FieldValidationError.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/FieldValidationError.java
@@ -1,0 +1,20 @@
+package co.com.pragma.crediya.api.exceptions;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Schema(description = "Details of a specific field validation error")
+public class FieldValidationError {
+
+    @Schema(description = "Field name that caused the validation error", example = "email")
+    private String field;
+
+    @Schema(description = "Validation error message for the field", example = "Email format is invalid")
+    private String message;
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/JwtAuthenticationException.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/JwtAuthenticationException.java
@@ -1,0 +1,23 @@
+package co.com.pragma.crediya.api.exceptions;
+
+import co.com.pragma.crediya.api.constants.AuthErrorMessages;
+
+public class JwtAuthenticationException extends RuntimeException {
+
+    public JwtAuthenticationException(String message) {
+        super(message);
+    }
+
+    public static JwtAuthenticationException invalidToken() {
+        return new JwtAuthenticationException(AuthErrorMessages.INVALID_TOKEN);
+    }
+
+    public static JwtAuthenticationException expiredToken() {
+        return new JwtAuthenticationException(AuthErrorMessages.EXPIRED_TOKEN);
+    }
+
+    public static JwtAuthenticationException missingToken() {
+        return new JwtAuthenticationException(AuthErrorMessages.MISSING_TOKEN);
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/ProblemDetails.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/ProblemDetails.java
@@ -1,0 +1,71 @@
+package co.com.pragma.crediya.api.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(
+        name = "ProblemDetails",
+        description = "Standardized error response body following RFC 7807 style"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProblemDetails {
+
+    @Schema(description = "Short, human-readable title of the error", example = "Invalid Request")
+    private String title;
+
+    @Schema(description = "Detailed description of the error", example = "Invalid credentials provided. Please check your email and password.")
+    private String message;
+
+    @Schema(description = "HTTP status code", example = "400")
+    private int status;
+
+    @JsonIgnore
+    private HttpStatus httpStatus;
+
+    @Schema(
+            description = "List of field-level validation errors (if any)",
+            implementation = FieldValidationError.class
+    )
+    private List<FieldValidationError> errors;
+
+    @Schema(description = "Timestamp when the error occurred", example = "2025-08-27 15:45:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+
+    public ProblemDetails(String title, String message, HttpStatus status, List<FieldValidationError> errors) {
+        this.title = title;
+        this.message = message;
+        this.httpStatus = status;
+        this.status = status.value();
+        this.errors = errors;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public static ProblemDetails forbidden(String title, String message) {
+        return new ProblemDetails(title, message, HttpStatus.FORBIDDEN, null);
+    }
+
+    public static ProblemDetails unauthorized(String title, String message) {
+        return new ProblemDetails(title, message, HttpStatus.UNAUTHORIZED, null);
+    }
+
+    public static ProblemDetails badRequest(String title, List<FieldValidationError> errors) {
+        return new ProblemDetails(title, null, HttpStatus.BAD_REQUEST, errors);
+    }
+
+    @JsonIgnore
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/CustomAccessDeniedHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package co.com.pragma.crediya.api.exceptions.handler;
+
+import co.com.pragma.crediya.api.constants.AuthErrorMessages;
+import co.com.pragma.crediya.api.constants.HttpErrorTitles;
+import co.com.pragma.crediya.api.exceptions.ProblemDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.server.authorization.ServerAccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements ServerAccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        response.setStatusCode(HttpStatus.FORBIDDEN);
+
+        ProblemDetails problemDetails = ProblemDetails.forbidden(HttpErrorTitles.FORBIDDEN, AuthErrorMessages.FORBIDDEN_ACCESS);
+
+        return Mono.fromCallable(() -> objectMapper.writeValueAsBytes(problemDetails))
+                .map(response.bufferFactory()::wrap)
+                .flatMap(buffer -> response.writeWith(Mono.just(buffer)))
+                .onErrorResume(e -> {
+                    byte[] fallbackBytes = ("{\"title\":\"" + HttpErrorTitles.FORBIDDEN + "\",\"message\":\"" + AuthErrorMessages.FORBIDDEN_ACCESS + "\"}").getBytes();
+                    DataBuffer buffer = response.bufferFactory().wrap(fallbackBytes);
+                    return response.writeWith(Mono.just(buffer));
+                });
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package co.com.pragma.crediya.api.exceptions.handler;
+
+import co.com.pragma.crediya.api.constants.HttpErrorTitles;
+import co.com.pragma.crediya.api.exceptions.FieldValidationError;
+import co.com.pragma.crediya.api.exceptions.JwtAuthenticationException;
+import co.com.pragma.crediya.api.exceptions.ProblemDetails;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public GlobalExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.getHeaders().add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+
+        ProblemDetails problemDetails = createProblemDetails(ex);
+
+        response.setStatusCode(problemDetails.getHttpStatus());
+
+        try {
+            String responseBody = objectMapper.writeValueAsString(problemDetails);
+            DataBuffer buffer = response.bufferFactory().wrap(responseBody.getBytes());
+            return response.writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            return response.writeWith(Mono.empty());
+        }
+    }
+
+    private ProblemDetails createProblemDetails(Throwable ex) {
+        if (ex instanceof WebExchangeBindException bindEx) {
+            return handleWebExchangeBindException(bindEx);
+        }
+
+        if (ex instanceof JwtAuthenticationException) {
+            return ProblemDetails.unauthorized(HttpErrorTitles.UNAUTHORIZED, ex.getMessage());
+        }
+
+        return new ProblemDetails(HttpErrorTitles.INTERNAL_SERVER_ERROR, "An unexpected error occurred while processing your request. Please try again later.", HttpStatus.INTERNAL_SERVER_ERROR, null);
+    }
+
+    private ProblemDetails handleWebExchangeBindException(WebExchangeBindException ex) {
+        List<FieldValidationError> errors = ex.getBindingResult()
+                .getFieldErrors().stream()
+                .map(fieldError ->
+                        new FieldValidationError(fieldError.getField(), fieldError.getDefaultMessage()))
+                .toList();
+
+        return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, errors);
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/mapper/ApprovedApplicationsSummaryRestMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/mapper/ApprovedApplicationsSummaryRestMapper.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.api.mapper;
+
+
+import co.com.pragma.crediya.api.dto.ApprovedApplicationsSummaryResponse;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface ApprovedApplicationsSummaryRestMapper {
+
+    ApprovedApplicationsSummaryResponse toResponse(ApprovedApplicationSummary approvedApplicationSummary);
+
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
@@ -1,0 +1,85 @@
+package co.com.pragma.crediya.api;
+
+import co.com.pragma.crediya.api.config.security.SecurityConfig;
+import co.com.pragma.crediya.api.config.security.SecurityContextRepository;
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.dto.ApprovedApplicationsSummaryResponse;
+import co.com.pragma.crediya.api.exceptions.handler.CustomAccessDeniedHandler;
+import co.com.pragma.crediya.api.mapper.ApprovedApplicationsSummaryRestMapper;
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import co.com.pragma.crediya.usecase.loan.ApprovedApplicationSummaryUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(classes = {
+        RouterRest.class,
+        ReportsHandler.class,
+        SecurityConfig.class
+})
+@WebFluxTest
+class RouterRestTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private SecurityContextRepository securityContextRepository;
+
+    @MockitoBean
+    private CustomAccessDeniedHandler accessDeniedHandler;
+
+    @MockitoBean
+    private ApprovedApplicationsSummaryRestMapper mapper;
+
+    @MockitoBean
+    private ApprovedApplicationSummaryUseCase approvedApplicationSummaryUseCase;
+
+    private ApprovedApplicationSummary approvedApplicationSummary;
+
+    private ApprovedApplicationsSummaryResponse approvedApplicationsSummaryResponse;
+
+    @BeforeEach
+    void setup() {
+        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, null);
+
+        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, null);
+    }
+
+    @Test
+    @WithMockUser(authorities = {DomainConstants.ADMIN_ROLE})
+    void shouldGetApprovedApplicationsSummarySuccessfully() {
+        when(approvedApplicationSummaryUseCase.getApprovedApplicationsSummary())
+                .thenReturn(Mono.just(approvedApplicationSummary));
+
+        when(mapper.toResponse(any(ApprovedApplicationSummary.class)))
+                .thenReturn(approvedApplicationsSummaryResponse);
+
+        webTestClient.get()
+                .uri(ApiConstants.REPORTS_PATH)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(ApprovedApplicationsSummaryResponse.class)
+                .value(response -> {
+                            assertThat(response).isInstanceOf(ApprovedApplicationsSummaryResponse.class);
+                            assertThat(response).isNotNull();
+                            assertThat(response.getApprovedApplicationsCount()).isZero();
+                        }
+                );
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
@@ -1,0 +1,88 @@
+package co.com.pragma.crediya.api.config;
+
+import co.com.pragma.crediya.api.ReportsHandler;
+import co.com.pragma.crediya.api.RouterRest;
+import co.com.pragma.crediya.api.config.security.SecurityConfig;
+import co.com.pragma.crediya.api.config.security.SecurityContextRepository;
+import co.com.pragma.crediya.api.config.security.SecurityHeadersConfig;
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.dto.ApprovedApplicationsSummaryResponse;
+import co.com.pragma.crediya.api.exceptions.handler.CustomAccessDeniedHandler;
+import co.com.pragma.crediya.api.mapper.ApprovedApplicationsSummaryRestMapper;
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
+import co.com.pragma.crediya.model.loan.constants.ApprovedApplicationSummaryFieldNames;
+import co.com.pragma.crediya.usecase.loan.ApprovedApplicationSummaryUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(classes = {RouterRest.class, ReportsHandler.class})
+@WebFluxTest
+@Import({
+        CorsConfig.class,
+        SecurityHeadersConfig.class,
+        SecurityConfig.class
+})
+class ConfigTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private SecurityContextRepository securityContextRepository;
+
+    @MockitoBean
+    private CustomAccessDeniedHandler accessDeniedHandler;
+
+    @MockitoBean
+    private ApprovedApplicationsSummaryRestMapper mapper;
+
+    @MockitoBean
+    private ApprovedApplicationSummaryUseCase approvedApplicationSummaryUseCase;
+
+    private ApprovedApplicationSummary approvedApplicationSummary;
+
+    private ApprovedApplicationsSummaryResponse approvedApplicationsSummaryResponse;
+
+    @BeforeEach
+    void setup() {
+        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, null);
+
+        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, null);
+    }
+
+    @Test
+    @WithMockUser(authorities = {DomainConstants.ADMIN_ROLE})
+    void corsConfigurationShouldAllowOrigins() {
+        when(approvedApplicationSummaryUseCase.getApprovedApplicationsSummary())
+                .thenReturn(Mono.just(approvedApplicationSummary));
+
+        when(mapper.toResponse(any(ApprovedApplicationSummary.class)))
+                .thenReturn(approvedApplicationsSummaryResponse);
+
+        webTestClient.get()
+                .uri(ApiConstants.REPORTS_PATH)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals("Content-Security-Policy",
+                        "default-src 'self'; frame-ancestors 'self'; form-action 'self'")
+                .expectHeader().valueEquals("Strict-Transport-Security", "max-age=31536000;")
+                .expectHeader().valueEquals("X-Content-Type-Options", "nosniff")
+                .expectHeader().valueEquals("Server", "")
+                .expectHeader().valueEquals("Cache-Control", "no-store")
+                .expectHeader().valueEquals("Pragma", "no-cache")
+                .expectHeader().valueEquals("Referrer-Policy", "strict-origin-when-cross-origin");
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/build.gradle
+++ b/infrastructure/entry-points/sqs-listener/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'software.amazon.awssdk:sqs'
+    implementation 'org.apache.logging.log4j:log4j-api'
+
+    // ObjectMapper
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/SQSProcessor.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/SQSProcessor.java
@@ -1,0 +1,32 @@
+package co.com.pragma.crediya.sqs.listener;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
+import co.com.pragma.crediya.usecase.loan.ApprovedApplicationSummaryUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.function.Function;
+
+@Service
+@RequiredArgsConstructor
+public class SQSProcessor implements Function<Message, Mono<Void>> {
+
+    private final ObjectMapper objectMapper;
+
+    private final ApprovedApplicationSummaryUseCase approvedApplicationSummaryUseCase;
+
+    @Override
+    public Mono<Void> apply(Message message) {
+        try {
+            ApprovedApplication response = objectMapper.readValue(message.body(), ApprovedApplication.class);
+
+            return approvedApplicationSummaryUseCase.recordApprovedApplication(response);
+        } catch (Exception e) {
+            return Mono.error(e);
+        }
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSConfig.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSConfig.java
@@ -1,0 +1,48 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import co.com.pragma.crediya.sqs.listener.helper.SQSListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.function.Function;
+
+@Configuration
+public class SQSConfig {
+
+    @Bean
+    public SQSListener sqsListener(SqsAsyncClient client, SQSProperties properties, Function<Message, Mono<Void>> fn) {
+        return SQSListener.builder()
+                .client(client)
+                .properties(properties)
+                .processor(fn)
+                .build()
+                .start();
+    }
+
+    @Bean
+    public SqsAsyncClient configSqs(SQSProperties properties, MetricPublisher publisher) {
+        return SqsAsyncClient.builder()
+                .region(Region.of(properties.region()))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .credentialsProvider(getProviderChain())
+                .build();
+    }
+
+    private AwsCredentialsProviderChain getProviderChain() {
+        return AwsCredentialsProviderChain.builder()
+                .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
+                .addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .addCredentialsProvider(ProfileCredentialsProvider.create())
+                .addCredentialsProvider(ContainerCredentialsProvider.builder().build())
+                .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+                .build();
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "entrypoint.sqs")
+public record SQSProperties(
+        String region,
+        String queueUrl,
+        String loanApprovedEventsQueueQueueName,
+        int waitTimeSeconds,
+        int visibilityTimeoutSeconds,
+        int maxNumberOfMessages,
+        int numberOfThreads) {
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/helper/SQSListener.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/helper/SQSListener.java
@@ -1,0 +1,90 @@
+package co.com.pragma.crediya.sqs.listener.helper;
+
+import co.com.pragma.crediya.sqs.listener.config.SQSProperties;
+import lombok.Builder;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+@Log4j2
+@Builder
+public class SQSListener {
+
+    private final SqsAsyncClient client;
+
+    private final SQSProperties properties;
+
+    private final Function<Message, Mono<Void>> processor;
+
+    private String operation;
+
+    public SQSListener start() {
+        this.operation = "MessageFrom:" + properties.queueUrl();
+
+        ExecutorService service = Executors.newFixedThreadPool(properties.numberOfThreads());
+        Flux<Void> flow = listenRetryRepeat().publishOn(Schedulers.fromExecutorService(service));
+        for (var i = 0; i < properties.numberOfThreads(); i++) {
+            flow.subscribe();
+        }
+
+        return this;
+    }
+
+    private Flux<Void> listenRetryRepeat() {
+        return listen()
+                .doOnError(e -> log.error("Error listening sqs queue", e))
+                .repeat();
+    }
+
+    private Flux<Void> listen() {
+        return getMessages()
+                .flatMap(message -> processor.apply(message)
+                        .name(properties.loanApprovedEventsQueueQueueName())
+                        .tag("operation", operation)
+                        .then(confirm(message)))
+                .onErrorContinue((e, o) -> log.error("Error listening sqs message", e));
+    }
+
+    private Mono<Void> confirm(Message message) {
+        String queueUrl = properties.queueUrl() + properties.loanApprovedEventsQueueQueueName();
+
+        return Mono.fromCallable(() -> getDeleteMessageRequest(message.receiptHandle(), queueUrl))
+                .flatMap(request -> Mono.fromFuture(client.deleteMessage(request)))
+                .then();
+    }
+
+    private Flux<Message> getMessages() {
+        String queueUrl = properties.queueUrl() + properties.loanApprovedEventsQueueQueueName();
+
+        return Mono.fromCallable(() -> getReceiveMessageRequest(queueUrl))
+                .flatMap(request -> Mono.fromFuture(client.receiveMessage(request)))
+                .doOnNext(response -> log.info("{} received messages from sqs", response.messages().size()))
+                .flatMapMany(response -> Flux.fromIterable(response.messages()));
+    }
+
+    private ReceiveMessageRequest getReceiveMessageRequest(String queueUrl) {
+        return ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(properties.maxNumberOfMessages())
+                .waitTimeSeconds(properties.waitTimeSeconds())
+                .visibilityTimeout(properties.visibilityTimeoutSeconds())
+                .build();
+    }
+
+    private DeleteMessageRequest getDeleteMessageRequest(String receiptHandle, String queueUrl) {
+        return DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build();
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/config/SQSConfigTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/config/SQSConfigTest.java
@@ -1,0 +1,44 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.metrics.LoggingMetricPublisher;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQSConfigTest {
+
+    private static final String REGION = "us-east-1";
+
+    private static final String QUEUE_URL = "http://queue-url/";
+
+    private static final String LOAN_APPROVED_EVENTS_QUEUE_NAME = "LoanApprovedEvents";
+
+    private SQSConfig sqsConfig;
+
+    private SQSProperties sqsProperties;
+
+    @Mock
+    private SqsAsyncClient sqsAsyncClient;
+
+    @BeforeEach
+    void init() {
+        sqsProperties = new SQSProperties(REGION, QUEUE_URL, LOAN_APPROVED_EVENTS_QUEUE_NAME, 20, 10, 10, 1);
+        sqsConfig = new SQSConfig();
+    }
+
+    @Test
+    void configSQSListenerIsNotNull() {
+        assertThat(sqsConfig.sqsListener(sqsAsyncClient, sqsProperties, message -> Mono.empty())).isNotNull();
+    }
+
+    @Test
+    void configSqsIsNotNull() {
+        var loggingMetricPublisher = LoggingMetricPublisher.create();
+        assertThat(sqsConfig.configSqs(sqsProperties, loggingMetricPublisher)).isNotNull();
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/helper/SQSListenerTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/helper/SQSListenerTest.java
@@ -1,0 +1,63 @@
+package co.com.pragma.crediya.sqs.listener.helper;
+
+import co.com.pragma.crediya.sqs.listener.config.SQSProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class SQSListenerTest {
+
+    @Mock
+    private SqsAsyncClient asyncClient;
+
+    private SQSProperties sqsProperties;
+
+    @BeforeEach
+    void setUp() {
+        sqsProperties = new SQSProperties(
+                "us-east-1",
+                "http://localhost:4566",
+                "queueName",
+                20,
+                30,
+                10,
+                1
+        );
+
+        var message = Message.builder().body("message").receiptHandle("rh").build();
+        var deleteMessageResponse = DeleteMessageResponse.builder().build();
+        var messageResponse = ReceiveMessageResponse.builder().messages(message).build();
+
+        lenient().when(asyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(messageResponse));
+        lenient().when(asyncClient.deleteMessage(any(DeleteMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(deleteMessageResponse));
+    }
+
+    @Test
+    void listenerTest() {
+        var sqsListener = SQSListener.builder()
+                .client(asyncClient)
+                .properties(sqsProperties)
+                .processor(msg -> Mono.just(1).then())
+                .build();
+
+        Flux<Void> flow = ReflectionTestUtils.invokeMethod(sqsListener, "listen");
+        StepVerifier.create(flow).verifyComplete();
+    }
+
+}

--- a/infrastructure/helpers/metrics/build.gradle
+++ b/infrastructure/helpers/metrics/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'org.springframework:spring-context'
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'software.amazon.awssdk:metrics-spi'
+}

--- a/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisher.java
+++ b/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisher.java
@@ -1,0 +1,49 @@
+package co.com.pragma.crediya.metrics.aws;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+@Component
+@AllArgsConstructor
+public class MicrometerMetricPublisher implements MetricPublisher {
+
+    private final ExecutorService service;
+
+    private final MeterRegistry registry;
+
+    @Override
+    public void publish(MetricCollection metricCollection) {
+        service.submit(() -> {
+            List<Tag> tags = buildTags(metricCollection);
+            metricCollection.stream()
+                    .filter(metricRecord -> metricRecord.value() instanceof Duration || metricRecord.value() instanceof Integer)
+                    .forEach(metricRecord -> {
+                        if (metricRecord.value() instanceof Duration) {
+                            registry.timer(metricRecord.metric().name(), tags).record((Duration) metricRecord.value());
+                        } else if (metricRecord.value() instanceof Integer) {
+                            registry.counter(metricRecord.metric().name(), tags).increment((Integer) metricRecord.value());
+                        }
+                    });
+        });
+    }
+
+    @Override
+    public void close() {
+        // Something
+    }
+
+    private List<Tag> buildTags(MetricCollection metricCollection) {
+        return metricCollection.stream()
+                .filter(metricRecord -> metricRecord.value() instanceof String || metricRecord.value() instanceof Boolean)
+                .map(metricRecord -> Tag.of(metricRecord.metric().name(), metricRecord.value().toString()))
+                .toList();
+    }
+}

--- a/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfig.java
+++ b/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfig.java
@@ -1,0 +1,19 @@
+package co.com.pragma.crediya.metrics.aws.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class MetricsConfig {
+
+    public static final String AWS_METRICS_EXECUTOR = "awsMetricsExecutor";
+
+    @Bean(name = AWS_METRICS_EXECUTOR, destroyMethod = "shutdown")
+    public ExecutorService awsMetricsExecutor() {
+        return Executors.newFixedThreadPool(10);
+    }
+
+}

--- a/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisherTest.java
+++ b/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisherTest.java
@@ -1,0 +1,128 @@
+package co.com.pragma.crediya.metrics.aws;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricRecord;
+import software.amazon.awssdk.metrics.SdkMetric;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MicrometerMetricPublisherTest {
+
+    @Mock
+    private ExecutorService mockExecutor;
+
+    @Mock
+    private MetricCollection mockMetricCollection;
+
+    @Mock
+    private MetricRecord<Duration> apiCallDurationRecord;
+
+    @Mock
+    private MetricRecord<Integer> retryAttemptsRecord;
+
+    @Mock
+    private MetricRecord<String> serviceIdRecord;
+
+    @Mock
+    private MetricRecord<Boolean> successfulRecord;
+
+    @Mock
+    private SdkMetric<Duration> apiCallDurationMetric;
+
+    @Mock
+    private SdkMetric<Integer> retryAttemptsMetric;
+
+    @Mock
+    private SdkMetric<String> serviceIdMetric;
+
+    @Mock
+    private SdkMetric<Boolean> successfulMetric;
+
+    private MeterRegistry meterRegistry;
+
+    private MicrometerMetricPublisher publisher;
+
+    public static final String API_CALL_DURATION = "ApiCallDuration";
+
+    public static final String RETRY_COUNT = "RetryCount";
+
+    public static final String SQS = "SQS";
+
+    public static final String SERVICE_ID = "ServiceId";
+
+    public static final String SUCCESSFUL = "Successful";
+
+    public static final String TRUE = "true";
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+
+        publisher = new MicrometerMetricPublisher(mockExecutor, meterRegistry);
+    }
+
+    @Test
+    @DisplayName("Publish AWS SDK metrics to Micrometer registry with correct timers, counters and tags")
+    void publish_shouldConvertAndRecordMetrics() {
+        when(apiCallDurationRecord.value()).thenReturn(Duration.ofMillis(150));
+        when(apiCallDurationRecord.metric()).thenReturn(apiCallDurationMetric);
+        when(apiCallDurationMetric.name()).thenReturn(API_CALL_DURATION);
+
+        when(retryAttemptsRecord.value()).thenReturn(2);
+        when(retryAttemptsRecord.metric()).thenReturn(retryAttemptsMetric);
+        when(retryAttemptsMetric.name()).thenReturn(RETRY_COUNT);
+
+        when(serviceIdRecord.value()).thenReturn(SQS);
+        when(serviceIdRecord.metric()).thenReturn(serviceIdMetric);
+        when(serviceIdMetric.name()).thenReturn(SERVICE_ID);
+
+        when(successfulRecord.value()).thenReturn(true);
+        when(successfulRecord.metric()).thenReturn(successfulMetric);
+        when(successfulMetric.name()).thenReturn(SUCCESSFUL);
+
+        when(mockMetricCollection.stream()).thenAnswer(invocation -> Stream.of(apiCallDurationRecord, retryAttemptsRecord, serviceIdRecord, successfulRecord));
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+        publisher.publish(mockMetricCollection);
+        verify(mockExecutor).submit(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+
+        Timer apiCallTimer = meterRegistry.find(API_CALL_DURATION).timer();
+        assertThat(apiCallTimer).isNotNull();
+        assertThat(apiCallTimer.count()).isEqualTo(1);
+        assertThat(apiCallTimer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS)).isEqualTo(150);
+        assertThat(apiCallTimer.getId().getTags()).containsExactlyInAnyOrder(
+                Tag.of(SERVICE_ID, SQS),
+                Tag.of(SUCCESSFUL, TRUE)
+        );
+
+        Counter retryCounter = meterRegistry.find(RETRY_COUNT).counter();
+        assertThat(retryCounter).isNotNull();
+        assertThat(retryCounter.count()).isEqualTo(2);
+        assertThat(retryCounter.getId().getTags()).containsExactlyInAnyOrder(
+                Tag.of(SERVICE_ID, SQS),
+                Tag.of(SUCCESSFUL, TRUE)
+        );
+    }
+
+}

--- a/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfigTest.java
+++ b/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfigTest.java
@@ -1,0 +1,24 @@
+package co.com.pragma.crediya.metrics.aws.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsConfigTest {
+
+    @Test
+    void awsMetricsExecutorBean_shouldBeCreated() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(MetricsConfig.class)) {
+            ExecutorService executorService = (ExecutorService) context.getBean(MetricsConfig.AWS_METRICS_EXECUTOR);
+            assertThat(executorService).isNotNull();
+            assertThat(executorService.isShutdown()).isFalse();
+        }
+    }
+
+}

--- a/main.gradle
+++ b/main.gradle
@@ -28,6 +28,7 @@ subprojects {
     }
 
     dependencies {
+		implementation platform('software.amazon.awssdk:bom:2.33.1')
         implementation 'io.projectreactor:reactor-core'
         implementation 'io.projectreactor.addons:reactor-extra'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,15 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':jwt'
+project(':jwt').projectDir = file('./infrastructure/driven-adapters/jwt')
+include ':logger'
+project(':logger').projectDir = file('./infrastructure/driven-adapters/logger')
+include ':reactive-web'
+project(':reactive-web').projectDir = file('./infrastructure/entry-points/reactive-web')
+include ':metrics'
+project(':metrics').projectDir = file('./infrastructure/helpers/metrics')
+include ':dynamo-db'
+project(':dynamo-db').projectDir = file('./infrastructure/driven-adapters/dynamo-db')
+include ':sqs-listener'
+project(':sqs-listener').projectDir = file('./infrastructure/entry-points/sqs-listener')


### PR DESCRIPTION
- Expose endpoint GET /api/v1/reports to retrieve total approved loan requests
- Integrate DynamoDB as persistence layer for loan count
- Consume SQS events emitted by loan applications microservice on loan approval
- Update counter in DynamoDB
- Add trace logs for monitoring and debugging