### PR TITLE
feat(reports): include total approved loan amount in reporting

### DIFF
--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
@@ -1,9 +1,11 @@
 package co.com.pragma.crediya.model.loan;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record ApprovedApplication(
         UUID id,
+        BigDecimal amount,
         OffsetDateTime approvedAt) {
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplicationSummary.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplicationSummary.java
@@ -1,9 +1,11 @@
 package co.com.pragma.crediya.model.loan;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 public record ApprovedApplicationSummary(
         String id,
         long approvedApplicationsCount,
+        BigDecimal approvedApplicationsAmount,
         Instant lastUpdated) {
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApprovedApplicationSummaryFieldNames.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApprovedApplicationSummaryFieldNames.java
@@ -13,6 +13,8 @@ public final class ApprovedApplicationSummaryFieldNames {
 
     public static final String APPROVED_APPLICATIONS_COUNT = "approvedApplicationsCount";
 
+    public static final String APPROVED_APPLICATIONS_AMOUNT =  "approvedApplicationsAmount";
+
     public static final String LAST_UPDATED = "lastUpdated";
 
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApprovedApplicationSummaryRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApprovedApplicationSummaryRepository.java
@@ -3,9 +3,11 @@ package co.com.pragma.crediya.model.loan.gateways;
 import co.com.pragma.crediya.model.loan.ApprovedApplicationSummary;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 public interface ApprovedApplicationSummaryRepository {
 
-    Mono<ApprovedApplicationSummary> incrementSummary(long countToAdd);
+    Mono<ApprovedApplicationSummary> incrementSummary(long countToAdd, BigDecimal amountToAdd);
 
     Mono<ApprovedApplicationSummary> getSummary();
 

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApprovedApplicationSummaryUseCase.java
@@ -11,17 +11,21 @@ public record ApprovedApplicationSummaryUseCase(ApprovedApplicationSummaryReposi
     public Mono<Void> recordApprovedApplication(ApprovedApplication application) {
         logger.info("Recording approved application ID {} at {}", application.id(), application.approvedAt());
 
-        return repository.incrementSummary(1L)
-                .doOnSuccess(summary -> logger.info("Updated summary: total approved count = {}", summary.approvedApplicationsCount()))
+        return repository.incrementSummary(1L, application.amount())
+                .doOnSuccess(summary ->
+                        logger.info("Updated summary: total approved count = {}, total approved amount = {}",
+                                summary.approvedApplicationsCount(), summary.approvedApplicationsAmount()))
                 .doOnError(e -> logger.error("Failed to update approved applications summary. Reason: {}", e.getMessage(), e))
                 .then();
     }
 
     public Mono<ApprovedApplicationSummary> getApprovedApplicationsSummary() {
-        logger.info("Retrieving  approved applications summary");
+        logger.info("Retrieving approved applications summary");
 
         return repository.getSummary()
-                .doOnSuccess(summary -> logger.info("Current summary: total approved count = {}", summary.approvedApplicationsCount()))
+                .doOnSuccess(summary ->
+                        logger.info("Current summary: total approved count = {}, total approved amount = {}",
+                                summary.approvedApplicationsCount(), summary.approvedApplicationsAmount()))
                 .doOnError(e -> logger.error("Failed to retrieve approved applications summary. Reason: {}", e.getMessage(), e));
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ApprovedApplicationsSummaryResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ApprovedApplicationsSummaryResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 @Getter
@@ -16,6 +17,8 @@ import java.time.Instant;
 public class ApprovedApplicationsSummaryResponse {
 
     private long approvedApplicationsCount;
+
+    private BigDecimal approvedApplicationsAmount;
 
     private Instant lastUpdated;
 

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -54,9 +56,9 @@ class RouterRestTest {
 
     @BeforeEach
     void setup() {
-        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, null);
+        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, BigDecimal.ZERO, null);
 
-        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, null);
+        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, BigDecimal.ZERO, null);
     }
 
     @Test

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -57,9 +59,9 @@ class ConfigTest {
 
     @BeforeEach
     void setup() {
-        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, null);
+        approvedApplicationSummary = new ApprovedApplicationSummary(ApprovedApplicationSummaryFieldNames.SUMMARY, 0, BigDecimal.ZERO, null);
 
-        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, null);
+        approvedApplicationsSummaryResponse = new ApprovedApplicationsSummaryResponse(0, BigDecimal.ZERO, null);
     }
 
     @Test


### PR DESCRIPTION
- Extend ApprovedApplication, ApprovedApplicationSummary and ApprovedApplicationsSummaryResponse to include amount
- Update ApprovedApplicationSummaryRepository and use case to handle amount
- Modify DynamoDB adapter to increment and persist approvedApplicationsAmount
- Update converter to map amount from DynamoDB attributes
- Update unit tests for use case, adapter, and REST layer to verify amount handling
- Add trace logs for amount aggregation