### PR TITLE
feat(reports): migrate secrets to AWS Secrets Manager

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-	implementation project(':sqs-listener')
-	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
-	implementation project(':dynamo-db')
-	implementation project(':metrics')
-	implementation project(':reactive-web')
-	implementation project(':logger')
-	implementation project(':jwt')
+    implementation 'com.github.bancolombia:aws-secrets-manager-async:4.4.34'
+    implementation 'software.amazon.awssdk:sts'
+    implementation project(':sqs-listener')
+    implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+    implementation project(':dynamo-db')
+    implementation project(':metrics')
+    implementation project(':reactive-web')
+    implementation project(':logger')
+    implementation project(':jwt')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/applications/app-service/src/main/java/co/com/pragma/crediya/config/SecretsConfig.java
+++ b/applications/app-service/src/main/java/co/com/pragma/crediya/config/SecretsConfig.java
@@ -1,0 +1,44 @@
+package co.com.pragma.crediya.config;
+
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import co.com.bancolombia.secretsmanager.config.AWSSecretsManagerConfig;
+import co.com.bancolombia.secretsmanager.connector.AWSSecretManagerConnectorAsync;
+import co.com.pragma.crediya.jwt.config.JwtProperties;
+import co.com.pragma.crediya.sqs.listener.config.SQSProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+
+@Configuration
+public class SecretsConfig {
+
+    @Bean
+    public GenericManagerAsync getSecretManager(@Value("${aws.region}") String region) {
+        return new AWSSecretManagerConnectorAsync(getConfig(region));
+    }
+
+    private AWSSecretsManagerConfig getConfig(String region) {
+        return AWSSecretsManagerConfig.builder()
+                .region(Region.of(region))
+                .cacheSize(5)
+                .cacheSeconds(3600)
+                .build();
+    }
+
+    @Bean
+    public JwtProperties jwtProperties(
+            final GenericManagerAsync connector, @Value("${aws.jwt.secretName}") String secretName) throws SecretException {
+        return connector.getSecret(secretName, JwtProperties.class)
+                .block();
+    }
+
+    @Bean
+    public SQSProperties sqsProperties(
+            final GenericManagerAsync connector, @Value("${aws.sqs.listener.secretName}") String secretName) throws SecretException {
+        return connector.getSecret(secretName, SQSProperties.class)
+                .block();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application-dev.yaml
+++ b/applications/app-service/src/main/resources/application-dev.yaml
@@ -1,21 +1,10 @@
 aws:
-  region: "${AWS_SQS_REGION}"
-
-entrypoint:
+  region: "${AWS_REGION}"
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
   sqs:
-    region: "${AWS_SQS_REGION}"
-    queueUrl: "${AWS_SQS_QUEUE_URL}"
-    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
-    waitTimeSeconds: 20
-    maxNumberOfMessages: 10
-    visibilityTimeoutSeconds: 10
-    numberOfThreads: 1
-
-application:
-  security:
-    jwt:
-      expiration: 3600000
-      secret-key: "${JWT_SECRET_KEY}"
+    listener:
+      secretName: "${AWS_SQS_LISTENER_SECRET_NAME}"
 
 logging:
   level:

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -1,23 +1,12 @@
 aws:
-  region: "${AWS_SQS_REGION}"
+  region: "${AWS_REGION}"
   dynamodb:
     endpoint: "${AWS_DYNAMODB_ENDPOINT:http://localhost:8000}"
-
-entrypoint:
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
   sqs:
-    region: "${AWS_SQS_REGION}"
-    queueUrl: "${AWS_SQS_QUEUE_URL}"
-    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
-    waitTimeSeconds: 20
-    maxNumberOfMessages: 10
-    visibilityTimeoutSeconds: 10
-    numberOfThreads: 1
-
-application:
-  security:
-    jwt:
-      expiration: 7200000
-      secret-key: "${JWT_SECRET_KEY}"
+    listener:
+      secretName: "${AWS_SQS_LISTENER_SECRET_NAME}"
 
 logging:
   level:

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -1,22 +1,11 @@
 aws:
-  region: "${AWS_SQS_REGION}"
-
-entrypoint:
+  region: "${AWS_REGION}"
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
   sqs:
-    region: "${AWS_SQS_REGION}"
-    queueUrl: "${AWS_SQS_QUEUE_URL}"
-    loanApprovedEventsQueueQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
-    waitTimeSeconds: 20
-    maxNumberOfMessages: 10
-    visibilityTimeoutSeconds: 10
-    numberOfThreads: 1
-
-application:
-  security:
-    jwt:
-      expiration: 1800000
-      secret-key: "${JWT_SECRET_KEY}"
+    listener:
+      secretName: "${AWS_SQS_LISTENER_SECRET_NAME}"
 
 logging:
   level:
-    root: WARN
+    root: INFO

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -7,8 +7,9 @@ spring:
     add-properties: false
   profiles:
     active: "${SPRING_PROFILES_ACTIVE:local}"
+
 server:
-  port: "${PORT:8081}"
+  port: "${PORT:8082}"
 
 management:
   endpoints:

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfig.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/crediya/dynamodb/config/DynamoDBConfig.java
@@ -4,8 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
@@ -33,7 +33,7 @@ public class DynamoDBConfig {
     @Profile({"dev", "prod"})
     public DynamoDbAsyncClient amazonDynamoDBAsync(MetricPublisher publisher, @Value("${aws.region}") String region) {
         return DynamoDbAsyncClient.builder()
-                .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
                 .region(Region.of(region))
                 .overrideConfiguration(o -> o.addMetricPublisher(publisher))
                 .build();

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
@@ -32,7 +32,7 @@ public class JwtProviderAdapter implements JwtProviderPort {
     }
 
     private SecretKey getSecretKey() {
-        String secretKey = properties.getSecretKey();
+        String secretKey = properties.secretKey();
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
 
         return Keys.hmacShaKeyFor(keyBytes);

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
@@ -1,18 +1,4 @@
 package co.com.pragma.crediya.jwt.config;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
-@Getter
-@Setter
-@Configuration
-@ConfigurationProperties(prefix = "application.security.jwt")
-public class JwtProperties {
-
-    private String secretKey;
-
-    private long expiration;
-
+public record JwtProperties(String secretKey, long expiration) {
 }

--- a/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
+++ b/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
@@ -22,13 +22,10 @@ class JwtProviderAdapterTest {
 
     private User user;
 
-    private final JwtProperties properties = new JwtProperties();
+    private final JwtProperties properties = new JwtProperties("q/MbiTiaKL9wCSeISqOlOQvDjg7s+xmYRtNhYbq7T3A=", 10000L);
 
     @BeforeEach
     void setUp() {
-        properties.setSecretKey("q/MbiTiaKL9wCSeISqOlOQvDjg7s+xmYRtNhYbq7T3A=");
-        properties.setExpiration(10000L);
-
         adapter = new JwtProviderAdapter(properties);
 
         user = new User("johndoe@example.com");
@@ -40,7 +37,7 @@ class JwtProviderAdapterTest {
                 .id(UUID.randomUUID().toString())
                 .subject(user.email())
                 .claim(UserFieldNames.ROLES, List.of(DomainConstants.ADMIN_ROLE))
-                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.getSecretKey())))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.secretKey())))
                 .compact();
 
         Jwt jwt = adapter.parseToken(token);

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
@@ -1,8 +1,5 @@
 package co.com.pragma.crediya.sqs.listener.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "entrypoint.sqs")
 public record SQSProperties(
         String region,
         String queueUrl,


### PR DESCRIPTION
- Add AWS Secrets Manager
- Refactor application YAMLs (dev, local, prod) to use AWS secrets for JWT and SQS listener
- Update DynamoDBConfig to use DefaultCredentialsProvider for dev/prod profiles