### PR TITLE
feat(reports): apply unified base path for reports module

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ server:
 management:
   endpoints:
     web:
+      base-path: "/api/v1/reports/actuator"
       exposure:
         include: "health,prometheus"
   endpoint:
@@ -23,3 +24,9 @@ management:
 
 cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS}"
+
+springdoc:
+  api-docs:
+    path: "/api/v1/reports/api-docs"
+  swagger-ui:
+    path: "/api/v1/reports/swagger-ui.html"

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
@@ -24,7 +24,7 @@ public class RouterRest {
     @Bean
     @RouterOperations({
             @RouterOperation(
-                    path = ApiConstants.REPORTS_PATH,
+                    path = ApiConstants.BASE_PATH,
                     produces = {MediaType.APPLICATION_JSON_VALUE},
                     method = RequestMethod.GET,
                     beanClass = ReportsHandler.class,
@@ -51,7 +51,7 @@ public class RouterRest {
     })
     public RouterFunction<ServerResponse> routerFunction(ReportsHandler handler) {
         return RouterFunctions.route()
-                .GET(ApiConstants.REPORTS_PATH, serverRequest -> handler.getApprovedLoansCount())
+                .GET(ApiConstants.BASE_PATH, serverRequest -> handler.getApprovedLoansCount())
                 .build();
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .authorizeExchange(exchangeSpec -> exchangeSpec
                         .pathMatchers(ApiConstants.PUBLIC_PATTERNS)
                         .permitAll()
-                        .pathMatchers(HttpMethod.GET, ApiConstants.REPORTS_PATH)
+                        .pathMatchers(HttpMethod.GET, ApiConstants.BASE_PATH)
                         .hasAnyAuthority(
                                 DomainConstants.ADMIN_ROLE
                         )

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
@@ -7,15 +7,15 @@ public final class ApiConstants {
 
     public static final String API_V1 = "/api/v1";
 
-    public static final String REPORTS_PATH = API_V1 + "/reports";
+    public static final String BASE_PATH = API_V1 + "/reports";
 
     public static final String[] PUBLIC_PATTERNS = {
-            "/actuator",
-            "/actuator/health",
-            "/actuator/prometheus",
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html"
+            BASE_PATH + "/actuator",
+            BASE_PATH + "/actuator/health",
+            BASE_PATH + "/actuator/prometheus",
+            BASE_PATH + "/swagger-ui.html",
+            BASE_PATH + "/swagger-ui/**",
+            BASE_PATH + "/api-docs/**"
     };
 
     public static final String BEARER_PREFIX = "Bearer ";

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
@@ -71,7 +71,7 @@ class RouterRestTest {
                 .thenReturn(approvedApplicationsSummaryResponse);
 
         webTestClient.get()
-                .uri(ApiConstants.REPORTS_PATH)
+                .uri(ApiConstants.BASE_PATH)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
@@ -74,7 +74,7 @@ class ConfigTest {
                 .thenReturn(approvedApplicationsSummaryResponse);
 
         webTestClient.get()
-                .uri(ApiConstants.REPORTS_PATH)
+                .uri(ApiConstants.BASE_PATH)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().valueEquals("Content-Security-Policy",


### PR DESCRIPTION
- Define BASE_PATH constant (/api/v1/reports) in ApiConstants
- Replace REPORTS_PATH references with BASE_PATH across router and security configuration
- Update application.yaml to use BASE_PATH for actuator, OpenAPI docs and Swagger UI
- Adjust PUBLIC_PATTERNS to include BASE_PATH for actuator, swagger and api-docs endpoints